### PR TITLE
fix: repair refresh workflow UTC timestamp formatting

### DIFF
--- a/.github/workflows/usgs-earthquake-refresh.yml
+++ b/.github/workflows/usgs-earthquake-refresh.yml
@@ -68,6 +68,6 @@ jobs:
             exit 0
           }
 
-          $timestamp = Get-Date -AsUTC -Format "yyyy-MM-dd HH:mm:ss 'UTC'"
+          $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss 'UTC'")
           git commit -m "chore: refresh USGS earthquake exports ($timestamp)"
           git push


### PR DESCRIPTION
## Summary
- replace Get-Date -AsUTC with a PowerShell-compatible UTC formatting call
- restore the refresh workflow commit step on GitHub-hosted runners

## Validation
- reviewed the failed Actions log from run 23122249197
- patched the exact failing line in the refresh workflow

## Notes
- this hotfix follows the bootstrap merge and gets the scheduled pipeline back into a working state