### PR TITLE
feat: add minute-cadence refresh loop to workflow

### DIFF
--- a/.github/workflows/usgs-earthquake-refresh.yml
+++ b/.github/workflows/usgs-earthquake-refresh.yml
@@ -7,6 +7,14 @@ on:
         description: Optional override for the USGS map URL
         required: false
         type: string
+      iterations:
+        description: Optional override for how many refresh cycles to run in this workflow execution
+        required: false
+        type: string
+      interval_seconds:
+        description: Optional override for the target cadence between refresh cycle starts
+        required: false
+        type: string
   schedule:
     - cron: "2,7,12,17,22,27,32,37,42,47,52,57 * * * *"
 
@@ -29,15 +37,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.ref_name }}
 
-      - name: Publish USGS exports
+      - name: Refresh and publish USGS exports
         shell: powershell
         env:
           WORKFLOW_MAP_URL: ${{ github.event.inputs.map_url }}
           REPO_MAP_URL: ${{ vars.USGS_MAP_URL }}
+          WORKFLOW_ITERATIONS: ${{ github.event.inputs.iterations }}
+          WORKFLOW_INTERVAL_SECONDS: ${{ github.event.inputs.interval_seconds }}
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = "Stop"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           $mapUrl = if ($env:WORKFLOW_MAP_URL) {
             $env:WORKFLOW_MAP_URL
@@ -49,25 +63,64 @@ jobs:
             $env:DEFAULT_MAP_URL
           }
 
-          powershell -NoProfile -ExecutionPolicy Bypass -File ".\usgs_seismic_stream\publish-usgs-earthquakes.ps1" -MapUrl $mapUrl
-
-      - name: Commit refreshed exports
-        shell: powershell
-        run: |
-          Set-StrictMode -Version Latest
-          $ErrorActionPreference = "Stop"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git add usgs_seismic_stream/exports
-
-          $stagedChanges = git diff --cached --name-only
-          if (-not $stagedChanges) {
-            Write-Host "No export changes detected."
-            exit 0
+          $isScheduledRun = "${{ github.event_name }}" -eq "schedule"
+          $iterations = if ($env:WORKFLOW_ITERATIONS) {
+            [int]$env:WORKFLOW_ITERATIONS
+          }
+          elseif ($isScheduledRun) {
+            5
+          }
+          else {
+            1
           }
 
-          $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss 'UTC'")
-          git commit -m "chore: refresh USGS earthquake exports ($timestamp)"
-          git push
+          $intervalSeconds = if ($env:WORKFLOW_INTERVAL_SECONDS) {
+            [int]$env:WORKFLOW_INTERVAL_SECONDS
+          }
+          else {
+            60
+          }
+
+          if ($iterations -lt 1) {
+            throw "Iterations must be at least 1."
+          }
+
+          if ($intervalSeconds -lt 1) {
+            throw "Interval seconds must be at least 1."
+          }
+
+          $branchName = "${{ github.ref_name }}"
+          if ([string]::IsNullOrWhiteSpace($branchName)) {
+            $branchName = "main"
+          }
+
+          Write-Host ("Running {0} refresh cycle(s) at a target {1}-second cadence on branch {2}." -f $iterations, $intervalSeconds, $branchName)
+
+          for ($iteration = 1; $iteration -le $iterations; $iteration++) {
+            $cycleStartedAt = Get-Date
+            Write-Host ("Starting refresh cycle {0}/{1}." -f $iteration, $iterations)
+
+            powershell -NoProfile -ExecutionPolicy Bypass -File ".\usgs_seismic_stream\publish-usgs-earthquakes.ps1" -MapUrl $mapUrl
+
+            git add usgs_seismic_stream/exports
+            $stagedChanges = git diff --cached --name-only
+
+            if ($stagedChanges) {
+              $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss 'UTC'")
+              git commit -m "chore: refresh USGS earthquake exports ($timestamp)"
+              git pull --rebase origin $branchName
+              git push origin "HEAD:$branchName"
+            }
+            else {
+              Write-Host "No export changes detected in this cycle."
+            }
+
+            if ($iteration -lt $iterations) {
+              $elapsedSeconds = [int][Math]::Ceiling(((Get-Date) - $cycleStartedAt).TotalSeconds)
+              $sleepSeconds = [Math]::Max(0, $intervalSeconds - $elapsedSeconds)
+              Write-Host ("Cycle {0}/{1} completed in about {2} second(s). Sleeping {3} second(s) before the next cycle." -f $iteration, $iterations, $elapsedSeconds, $sleepSeconds)
+              if ($sleepSeconds -gt 0) {
+                Start-Sleep -Seconds $sleepSeconds
+              }
+            }
+          }

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Automated capabilities:
 
 - scheduled ingestion and export regeneration
 - manual workflow dispatch with optional map URL override
+- effective one-minute refresh cadence inside each scheduled workflow run
 - serialized refresh runs to avoid overlapping workflow commits
 - published export refresh under `usgs_seismic_stream/exports`
 - heartbeat monitoring for stale pipeline detection
@@ -199,7 +200,7 @@ To finish connecting this local folder to the GitHub repository you already crea
 4. set repository workflow permissions so `GITHUB_TOKEN` can write contents
 5. optionally add a repository variable named `USGS_MAP_URL`
 
-The refresh workflow is currently scheduled every 5 minutes on an off-minute cadence to reduce contention.
+GitHub Actions does not support a native one-minute cron schedule. To work around that, this repository keeps the cron trigger at every 5 minutes and runs a one-minute internal refresh loop inside each scheduled workflow execution.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- keep the GitHub cron trigger at 5 minutes but add an internal refresh loop
- let scheduled runs execute five refresh cycles at a target 60-second cadence
- document the one-minute workaround clearly in the README
- allow manual workflow dispatch to override iterations and interval seconds for testing

## Validation
- reviewed the workflow YAML after patching
- confirmed the README reflects the GitHub scheduling constraint and workaround

## Notes
- this is the closest GitHub-only approach to one-minute refreshes because native scheduled workflows cannot run every minute